### PR TITLE
Add task to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ jobs:
 - name: alert
   public: true
   plan:
+  - task: say-hello
+    config:
+      platform: linux
+      image: "docker:///ubuntu"
+      run:
+        path: echo
+        args: ["Hello, world!"]
   - put: alert
     params:
       text: Hi everybody!


### PR DESCRIPTION
Concourse will not run a job where the first thing in a job is a `put`. 

This change makes the example runnable so people won't run into #1 and get confused.
